### PR TITLE
Make args array contain an argument for every parameter of the method.

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -104,19 +104,15 @@ class Dispatcher
             if (is_array($msg->params)) {
                 $args = $msg->params;
             } else if (is_object($msg->params)) {
-                foreach (get_object_vars($msg->params) as $key => $value) {
-                    $position = -1;
-                    foreach ($parameters as $pos => $parameter) {
+                foreach ($parameters as $pos => $parameter) {
+                    $value = null;
+                    foreach(get_object_vars($msg->params) as $key => $val) {
                         if ($parameter->name === $key) {
-                            $position = $pos;
+                            $value = $val;
                             break;
                         }
                     }
-                    if ($position === -1) {
-                        // Unknown parameter, ignore
-                        continue;
-                    }
-                    $args[$position] = $value;
+                    $args[$pos] = $value;
                 }
             } else {
                 throw new Error('Params must be structured or omitted', ErrorCode::INVALID_REQUEST);


### PR DESCRIPTION
Currently if the received params object does not contain a certain parameter of the function
this parameter is simply omitted in the array, resulting in a displacement of the following
arguments.

This commit fills a missing parameter in the array by the value `null` so that at least all
parameters are represented in the args array.