### PR TITLE
Dispatcher::dispatch should return mixed

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -57,7 +57,7 @@ class Dispatcher
      * Calls the appropriate method handler for an incoming Message
      *
      * @param string|object $msg The incoming message
-     * @return Result|void
+     * @return mixed
      */
     public function dispatch($msg)
     {


### PR DESCRIPTION
We have no idea what the method returns, so `mixed` is the most appropriate return type.