### PR TITLE
chore: remove unused import

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace AdvancedJsonRpc;
 
-use Sabre\Event\Loop;
 use JsonMapper;
 use JsonMapper_Exception;
 use phpDocumentor\Reflection\DocBlockFactory;


### PR DESCRIPTION
Removed "use Sabre\Event\Loop" from imports in Dispatcher class. It's not used in any part of the code.