### PR TITLE
fix: update minimal reflection-docblock version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0",
-        "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
+        "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.0"


### PR DESCRIPTION
Hi @felixfbecker 

The `4.0.0` release has a bug.
https://github.com/phpDocumentor/ReflectionDocBlock/issues/111

This was fixed in `4.0.1`. But I don't see any reason to not require the last version.

Currently, when using `composer update --prefer-lowest`, the `4.0.0` version is installed.

This PR will avoid a lot of library to explicitly set the version of the reflection-dockblock, like psalm already did
https://github.com/vimeo/psalm/pull/3967