### PR TITLE
test: Add test for additional provided parameters

### DIFF
--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -72,5 +72,17 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->callsOfNestedTarget, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
     }
 
+    public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithoutArgs()
+    {
+        $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithoutArgs', ['arg' => new Argument('whatever')]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithoutArgs', [])]);
+    }
 
+    public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithTypeHint()
+    {
+        $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithTypeHint', ['arg' => new Argument('whatever'), 'arg2' => new Argument('anything')]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
+    }
 }


### PR DESCRIPTION
This PR adds two new tests with additional parameters (one for a method without parameters at all and one for a method that has a single parameter). Both test are green without any changes to the code.

I'm not certain if this is exactly what you mean in #1 but it is what I think you mean. If so it would resolve #1 Please let me know if this was misunderstood so I can adjust to the needs.