### PR TITLE
refactor: Switch to php documentor reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0",
-        "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+        "phpdocumentor/reflection": "^4.0"
+
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0"

--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -3,13 +3,9 @@ declare(strict_types = 1);
 
 namespace AdvancedJsonRpc;
 
+use AdvancedJsonRpc\Reflection\NativeReflection;
 use JsonMapper;
 use JsonMapper_Exception;
-use phpDocumentor\Reflection\DocBlockFactory;
-use phpDocumentor\Reflection\Types;
-use ReflectionException;
-use ReflectionMethod;
-use ReflectionNamedType;
 
 class Dispatcher
 {
@@ -24,21 +20,14 @@ class Dispatcher
     private $delimiter;
 
     /**
-     * method => ReflectionMethod[]
-     *
-     * @var ReflectionMethod
+     * @var Reflection\NativeReflection
      */
-    private $methods;
+    private $reflection;
 
     /**
-     * @var \phpDocumentor\Reflection\DocBlockFactory
+     * @var JsonMapper
      */
-    private $docBlockFactory;
-
-    /**
-     * @var \phpDocumentor\Reflection\Types\ContextFactory
-     */
-    private $contextFactory;
+    private $mapper;
 
     /**
      * @param object $target    The target object that should receive the method calls
@@ -48,9 +37,8 @@ class Dispatcher
     {
         $this->target = $target;
         $this->delimiter = $delimiter;
-        $this->docBlockFactory = DocBlockFactory::createInstance();
-        $this->contextFactory = new Types\ContextFactory();
         $this->mapper = new JsonMapper();
+        $this->reflection = new NativeReflection();
     }
 
     /**
@@ -81,33 +69,19 @@ class Dispatcher
             }
             $obj = $obj->$part;
         }
-        if (!isset($this->methods[$msg->method])) {
-            try {
-                $method = new ReflectionMethod($obj, $fn);
-                $this->methods[$msg->method] = $method;
-            } catch (ReflectionException $e) {
-                throw new Error($e->getMessage(), ErrorCode::METHOD_NOT_FOUND, null, $e);
-            }
-        }
-        $method = $this->methods[$msg->method];
-        $parameters = $method->getParameters();
-        if ($method->getDocComment()) {
-            $docBlock = $this->docBlockFactory->create(
-                $method->getDocComment(),
-                $this->contextFactory->createFromReflector($method->getDeclaringClass())
-            );
-            $paramTags = $docBlock->getTagsByName('param');
-        }
+
+        $method = $this->reflection->getMethodDetails($msg->method, $obj, $fn);
+
         $args = [];
         if (isset($msg->params)) {
             // Find out the position
             if (is_array($msg->params)) {
                 $args = $msg->params;
             } else if (is_object($msg->params)) {
-                foreach ($parameters as $pos => $parameter) {
+                foreach ($method->getParameters() as $pos => $parameter) {
                     $value = null;
                     foreach(get_object_vars($msg->params) as $key => $val) {
-                        if ($parameter->name === $key) {
+                        if ($parameter->getName() === $key) {
                             $value = $val;
                             break;
                         }
@@ -117,46 +91,25 @@ class Dispatcher
             } else {
                 throw new Error('Params must be structured or omitted', ErrorCode::INVALID_REQUEST);
             }
+
             foreach ($args as $position => $value) {
                 try {
                     // If the type is structured (array or object), map it with JsonMapper
                     if (is_object($value)) {
                         // Does the parameter have a type hint?
-                        $param = $parameters[$position];
+                        $param = $method->getParameters()[$position];
                         if ($param->hasType()) {
-                            $paramType = $param->getType();
-                            if ($paramType instanceof ReflectionNamedType) {
-                                // We have object data to map and want the class name.
-                                // This should not include the `?` if the type was nullable.
-                                $class = $paramType->getName();
-                            } else {
-                                // Fallback for php 7.0, which is still supported (and doesn't have nullable).
-                                $class = (string)$paramType;
-                            }
+                            $class = $param->getType()->getName();
                             $value = $this->mapper->map($value, new $class());
                         }
-                    } else if (is_array($value) && isset($docBlock)) {
-                        // Get the array type from the DocBlock
-                        $type = $paramTags[$position]->getType();
-                        // For union types, use the first one that is a class array (often it is SomeClass[]|null)
-                        if ($type instanceof Types\Compound) {
-                            for ($i = 0; $t = $type->get($i); $i++) {
-                                if (
-                                    $t instanceof Types\Array_
-                                    && $t->getValueType() instanceof Types\Object_
-                                    && (string)$t->getValueType() !== 'object'
-                                ) {
-                                    $class = (string)$t->getValueType()->getFqsen();
-                                    $value = $this->mapper->mapArray($value, [], $class);
-                                    break;
-                                }
-                            }
-                        } else if ($type instanceof Types\Array_) {
-                            $class = (string)$type->getValueType()->getFqsen();
-                            $value = $this->mapper->mapArray($value, [], $class);
-                        } else {
+                    } else if (is_array($value) && $method->getDocComment() !== '') {
+                        if (!array_key_exists($position, $method->getParamTags())) {
                             throw new Error('Type is not matching @param tag', ErrorCode::INVALID_PARAMS);
                         }
+
+                        // Get the array type from the DocBlock
+                        $class = $method->getParamTags()[$position]->getType()->getName();
+                        $value = $this->mapper->mapArray($value, [], $class);
                     }
                 } catch (JsonMapper_Exception $e) {
                     throw new Error($e->getMessage(), ErrorCode::INVALID_PARAMS, null, $e);

--- a/lib/Reflection/Dto/Method.php
+++ b/lib/Reflection/Dto/Method.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection\Dto;
+
+class Method
+{
+    /** @var string */
+    private $declaringClass;
+    /** @var string|null */
+    private $docComment;
+    /** @var Parameter[] */
+    private $parameters;
+    /** @var Parameter[] */
+    private $paramTags;
+
+    /**
+     * @param string|null $docComment
+     */
+    public function __construct(string $declaringClass, $docComment, array $parameters, array $paramTags)
+    {
+        $this->declaringClass = $declaringClass;
+        $this->docComment = $docComment;
+        $this->parameters = $parameters;
+        $this->paramTags = $paramTags;
+    }
+
+    public function getDeclaringClass(): string
+    {
+        return $this->declaringClass;
+    }
+
+    public function getDocComment(): string
+    {
+        return $this->docComment;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getParamTags(): array
+    {
+        return $this->paramTags;
+    }
+}

--- a/lib/Reflection/Dto/Method.php
+++ b/lib/Reflection/Dto/Method.php
@@ -6,34 +6,12 @@ namespace AdvancedJsonRpc\Reflection\Dto;
 
 class Method
 {
-    /** @var string */
-    private $declaringClass;
-    /** @var string|null */
-    private $docComment;
     /** @var Parameter[] */
     private $parameters;
-    /** @var Parameter[] */
-    private $paramTags;
 
-    /**
-     * @param string|null $docComment
-     */
-    public function __construct(string $declaringClass, $docComment, array $parameters, array $paramTags)
+    public function __construct(array $parameters)
     {
-        $this->declaringClass = $declaringClass;
-        $this->docComment = $docComment;
         $this->parameters = $parameters;
-        $this->paramTags = $paramTags;
-    }
-
-    public function getDeclaringClass(): string
-    {
-        return $this->declaringClass;
-    }
-
-    public function getDocComment(): string
-    {
-        return $this->docComment;
     }
 
     public function getParameters(): array
@@ -41,8 +19,13 @@ class Method
         return $this->parameters;
     }
 
-    public function getParamTags(): array
+    public function hasParameter(int $name): bool
     {
-        return $this->paramTags;
+        return array_key_exists($name, $this->parameters);
+    }
+
+    public function getParameter(int $name): Parameter
+    {
+        return $this->parameters[$name];
     }
 }

--- a/lib/Reflection/Dto/Parameter.php
+++ b/lib/Reflection/Dto/Parameter.php
@@ -30,6 +30,6 @@ class Parameter
 
     public function hasType(): bool
     {
-        return isset($this->type);
+        return $this->type !== null;
     }
 }

--- a/lib/Reflection/Dto/Parameter.php
+++ b/lib/Reflection/Dto/Parameter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection\Dto;
+
+
+class Parameter
+{
+    /** @var string */
+    private $name;
+    /** @var Type|null */
+    private $type;
+
+    public function __construct(string $name, Type $type = null)
+    {
+        $this->name = $name;
+        $this->type = $type;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    public function hasType(): bool
+    {
+        return isset($this->type);
+    }
+}

--- a/lib/Reflection/Dto/Type.php
+++ b/lib/Reflection/Dto/Type.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection\Dto;
+
+class Type
+{
+    /** @var string */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/lib/Reflection/NativeReflection.php
+++ b/lib/Reflection/NativeReflection.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection;
+
+
+use AdvancedJsonRpc\Error;
+use AdvancedJsonRpc\ErrorCode;
+use AdvancedJsonRpc\Reflection\Dto\Method;
+use AdvancedJsonRpc\Reflection\Dto\Parameter;
+use AdvancedJsonRpc\Reflection\Dto\Type;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Types;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+class NativeReflection
+{
+    /** @var DocBlockFactory */
+    private $docBlockFactory;
+    /** @var \phpDocumentor\Reflection\Types\ContextFactory */
+    private $contextFactory;
+    /** @var Method[] */
+    private $methods = [];
+
+    public function __construct()
+    {
+        $this->docBlockFactory = DocBlockFactory::createInstance();
+        $this->contextFactory = new Types\ContextFactory();
+    }
+
+    public function getMethodDetails($rpcMethod, $target, $nativeMethod): Method
+    {
+        if (array_key_exists($rpcMethod, $this->methods)) {
+            return $this->methods[$rpcMethod];
+        }
+
+        try {
+            $nativeMethod = new ReflectionMethod($target, $nativeMethod);
+        } catch (ReflectionException $e) {
+            throw new Error($e->getMessage(), ErrorCode::METHOD_NOT_FOUND, null, $e);
+        }
+
+        $paramTags = [];
+        if ($nativeMethod->getDocComment()) {
+            $docBlock = $this->docBlockFactory->create(
+                $nativeMethod->getDocComment(),
+                $this->contextFactory->createFromReflector($nativeMethod->getDeclaringClass())
+            );
+            $paramTags = $docBlock->getTagsByName('param');
+        }
+
+        $method = new Method(
+            $nativeMethod->getDeclaringClass()->getName(),
+            $nativeMethod->getDocComment() ?: null,
+            array_map(function($p) { return $this->mapNativeReflectionParameterToParameter($p); }, $nativeMethod->getParameters()),
+            array_map(function($p) { return $this->mapDocBlockTagToParameter($p); }, $paramTags)
+        );
+
+        $this->methods[$rpcMethod] = $method;
+
+        return $method;
+    }
+
+    private function mapNativeReflectionParameterToParameter(\ReflectionParameter $native): Parameter
+    {
+        $types = $this->mapNativeReflectionTypeToType($native->getType());
+        return new Parameter($native->getName(), $types);
+    }
+
+    private function mapDocBlockTagToParameter(Tag $tag): Parameter
+    {
+        $type = $tag->getType();
+        // For union types, use the first one that is a class array (often it is SomeClass[]|null)
+        if ($type instanceof Types\Compound) {
+            for ($i = 0; $t = $type->get($i); $i++) {
+                if (
+                    $t instanceof Types\Array_
+                    && $t->getValueType() instanceof Types\Object_
+                    && (string)$t->getValueType() !== 'object'
+                ) {
+                    return new Parameter($tag->getName(), new Type((string)$t->getValueType()->getFqsen()));
+                }
+            }
+        } else if ($type instanceof Types\Array_) {
+            return new Parameter($tag->getName(), new Type((string)$type->getValueType()->getFqsen()));
+        }
+    }
+
+    private function mapNativeReflectionTypeToType(\ReflectionType $native = null): Type
+    {
+        if ($native instanceof ReflectionNamedType) {
+            // We have object data to map and want the class name.
+            // This should not include the `?` if the type was nullable.
+            return new Type($native->getName());
+        } else {
+            // Fallback for php 7.0, which is still supported (and doesn't have nullable).
+            return new Type((string) $native);
+        }
+    }
+}

--- a/lib/Reflection/PhpDocumentorReflection.php
+++ b/lib/Reflection/PhpDocumentorReflection.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection;
+
+
+use AdvancedJsonRpc\Reflection\Dto\Method;
+use AdvancedJsonRpc\Reflection\Dto\Parameter;
+use AdvancedJsonRpc\Reflection\Dto\Type;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Php\Project;
+use phpDocumentor\Reflection\Php\ProjectFactory;
+use phpDocumentor\Reflection\Types;
+use ReflectionMethod;
+
+class PhpDocumentorReflection implements ReflectionInterface
+{
+
+    /** @var ProjectFactory */
+    private $projectFactory;
+
+    public function __construct()
+    {
+        $this->projectFactory = ProjectFactory::createInstance();
+    }
+
+    public function getMethodDetails($rpcMethod, $target, $nativeMethodName): Method
+    {
+        $nativeMethod = new ReflectionMethod($target, $nativeMethodName);
+        $projectFiles = [new LocalFile($nativeMethod->getFileName())];
+        /** @var Project $project */
+        $project = $this->projectFactory->create('php-advanced-json-rpc', $projectFiles);
+
+        /** @var \phpDocumentor\Reflection\Php\Class_ $class */
+        $class = $project->getFiles()[$nativeMethod->getFileName()]->getClasses()['\\' . $nativeMethod->class]; /* @todo add error handling of multiple classes in single file */
+        $methodName = '\\' . $nativeMethod->class . '::' . $nativeMethod->getName() . '()';
+        $method = $class->getMethods()[$methodName]; /* @todo add error handling for missing method */
+
+        $parameters = array_map(function ($a) { return $this->mapPhpDocumentorReflectionParameterToParameter($a); }, $method->getArguments());
+
+        /* Improve types from the doc block */
+        $docBlock = $method->getDocBlock();
+        if ($docBlock !== null) {
+            $docBlockParameters = [];
+
+            foreach ($method->getDocBlock()->getTagsByName('param') as $param) {
+                $docBlockParameters[$param->getVariableName()] = $this->mapDocBlockTagToParameter($param);
+            }
+
+            foreach ($parameters as $position => $param) {
+                if (array_key_exists($param->getName(), $docBlockParameters) && $docBlockParameters[$param->getName()]->hasType())
+                {
+                    $parameters[$position] = $docBlockParameters[$param->getName()];
+                }
+            }
+        }
+
+        return new Method($parameters);
+    }
+
+    private function mapPhpDocumentorReflectionParameterToParameter(Argument $argument): Parameter
+    {
+        $phpDocumentorType = $argument->getType();
+        if ($phpDocumentorType === null) {
+            return new Parameter($argument->getName());
+        }
+
+        return new Parameter($argument->getName(), new Type((string) $phpDocumentorType));
+    }
+
+    private function mapDocBlockTagToParameter(Tag $tag): Parameter
+    {
+        $type = $tag->getType();
+        // For union types, use the first one that is a class array (often it is SomeClass[]|null)
+        if ($type instanceof Types\Compound) {
+            for ($i = 0; $t = $type->get($i); $i++) {
+                if (
+                    $t instanceof Types\Array_
+                    && $t->getValueType() instanceof Types\Object_
+                    && (string)$t->getValueType() !== 'object'
+                ) {
+                    return new Parameter($tag->getVariableName(), new Type((string)$t->getValueType()->getFqsen()));
+                }
+            }
+        } else if ($type instanceof Types\Array_) {
+            return new Parameter($tag->getVariableName(), new Type((string)$type->getValueType()->getFqsen()));
+        }
+    }
+}

--- a/lib/Reflection/ReflectionInterface.php
+++ b/lib/Reflection/ReflectionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdvancedJsonRpc\Reflection;
+
+use AdvancedJsonRpc\Reflection\Dto\Method;
+
+interface ReflectionInterface
+{
+    public function getMethodDetails($rpcMethod, $target, $nativeMethod): Method;
+}


### PR DESCRIPTION
This draft pull request shows a rough implementation of how php-advanced-json-rpc could use PhpDocumentor Reflection. In order to resolve #9.
I've added this PR to have a more constructive discussion about the pros and cons. I've based this on the latest stable mayor version of PHPDocumentor Reflection (^4.0). That version only support PHP 7.2 and up (Which is causing the build to fail). This already raises some concern as this lib is aiming to support PHP 7.0 but that is already two years EOL (See https://www.php.net/supported-versions.php). So perhaps some updates are needed for this lib as well?

This PR has the following changes:
- Extracts the current implementation, based on the native reflection classes of PHP, into an interface (strategy pattern)
- Implements a PhpDocumentor Reflection implementation of above interface

In order to complete this PR the following is needed:
- [ ] Add unit tests for the new implementation
- [ ] Decide if the current approach with the Reflection abstraction layer is something that is desired
- [ ] Resolve any @TODO added in this PR
- [ ] General cleanup of the PR.
- [ ] Ensure if we have the optimal way of caching implemented in order to resolve #2 