### PR TITLE
test: Add test to proof docblock is being used when type hint is array

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -152,7 +152,7 @@ class Dispatcher
                                 }
                             }
                         } else if ($type instanceof Types\Array_) {
-                            $class = (string)$type->getValueType()->getFqsen();
+                            $class = (string) $type->getValueType()->getFqsen();
                             $value = $this->mapper->mapArray($value, [], $class);
                         } else {
                             throw new Error('Type is not matching @param tag', ErrorCode::INVALID_PARAMS);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -63,7 +63,6 @@ class DispatcherTest extends TestCase
         $this->assertEquals('Hello World', $result);
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithUnionTypeParamTag', [[new Argument('whatever')]])]);
     }
-
     public function testCallMethodWithTypeHintWithNamedArgsOnNestedTarget()
     {
         $result = $this->dispatcher->dispatch((string)new Request(1, 'nestedTarget->someMethodWithTypeHint', ['arg' => new Argument('whatever')]));
@@ -72,5 +71,11 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->callsOfNestedTarget, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
     }
 
+    public function testCallMethodWithArrayTypeHintAndDocblock(): void
+    {
+        $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithArrayTypeHint', ['args' => [new Argument('1'), new Argument('2')]]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithArrayTypeHint', [[new Argument('1'), new Argument('2')]])]);
+    }
 
 }

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -49,4 +49,13 @@ class Target
         $this->calls[] = new MethodCall('someMethodWithDifferentlyTypedArgs', func_get_args());
         return 'Hello World';
     }
+
+    /**
+     * @param Argument[] $args
+     */
+    public function someMethodWithArrayTypeHint(array $args): string
+    {
+        $this->calls[] = new MethodCall('someMethodWithArrayTypeHint', func_get_args());
+        return 'Hello World';
+    }
 }


### PR DESCRIPTION
This PR adds:
- An additional test to proof dokblocks are being used when type hint is array.

This will resolve #3 