### PR TITLE
test: Proof @param ?string is supported in current setup

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -152,7 +152,7 @@ class Dispatcher
                                 }
                             }
                         } else if ($type instanceof Types\Array_) {
-                            $class = (string)$type->getValueType()->getFqsen();
+                            $class = (string) $type->getValueType()->getFqsen();
                             $value = $this->mapper->mapArray($value, [], $class);
                         } else {
                             throw new Error('Type is not matching @param tag', ErrorCode::INVALID_PARAMS);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -77,7 +77,7 @@ class DispatcherTest extends TestCase
         $this->assertEquals('Hello World', $result);
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithArrayTypeHint', [[new Argument('1'), new Argument('2')]])]);
     }
-  
+
     public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithoutArgs()
     {
         $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithoutArgs', ['arg' => new Argument('whatever')]));
@@ -90,5 +90,12 @@ class DispatcherTest extends TestCase
         $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithTypeHint', ['arg' => new Argument('whatever'), 'arg2' => new Argument('anything')]));
         $this->assertEquals('Hello World', $result);
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
+    }
+
+    public function testSomeMethodWithNullableTypeParamTag(): void
+    {
+        $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithNullableTypeParamTag', ['arg' => null]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithNullableTypeParamTag', [null])]);
     }
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -72,5 +72,17 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->callsOfNestedTarget, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
     }
 
+    public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithoutArgs()
+    {
+        $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithoutArgs', ['arg' => new Argument('whatever')]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithoutArgs', [])]);
+    }
 
+    public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithTypeHint()
+    {
+        $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithTypeHint', ['arg' => new Argument('whatever'), 'arg2' => new Argument('anything')]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
+    }
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -63,7 +63,6 @@ class DispatcherTest extends TestCase
         $this->assertEquals('Hello World', $result);
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithUnionTypeParamTag', [[new Argument('whatever')]])]);
     }
-
     public function testCallMethodWithTypeHintWithNamedArgsOnNestedTarget()
     {
         $result = $this->dispatcher->dispatch((string)new Request(1, 'nestedTarget->someMethodWithTypeHint', ['arg' => new Argument('whatever')]));
@@ -72,6 +71,13 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->callsOfNestedTarget, [new MethodCall('someMethodWithTypeHint', [new Argument('whatever')])]);
     }
 
+    public function testCallMethodWithArrayTypeHintAndDocblock(): void
+    {
+        $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithArrayTypeHint', ['args' => [new Argument('1'), new Argument('2')]]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithArrayTypeHint', [[new Argument('1'), new Argument('2')]])]);
+    }
+  
     public function testCallMethodWithAdditionalProvidedParamsOnSomeMethodWithoutArgs()
     {
         $result = $this->dispatcher->dispatch((string) new Request(1, 'someMethodWithoutArgs', ['arg' => new Argument('whatever')]));

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -58,4 +58,13 @@ class Target
         $this->calls[] = new MethodCall('someMethodWithArrayTypeHint', func_get_args());
         return 'Hello World';
     }
+
+    /**
+     * @param ?string $arg
+     */
+    public function someMethodWithNullableTypeParamTag($arg): string
+    {
+        $this->calls[] = new MethodCall('someMethodWithNullableTypeParamTag', func_get_args());
+        return 'Hello World';
+    }
 }

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -49,4 +49,13 @@ class Target
         $this->calls[] = new MethodCall('someMethodWithDifferentlyTypedArgs', func_get_args());
         return 'Hello World';
     }
+
+    /**
+     * @param Argument[] $args
+     */
+    public function someMethodWithArrayTypeHint(array $args): string
+    {
+        $this->calls[] = new MethodCall('someMethodWithArrayTypeHint', func_get_args());
+        return 'Hello World';
+    }
 }


### PR DESCRIPTION
This PR adds:
- A test to proof `@param ?string` is supported.

This would resolve #13 