### PR TITLE
fix: allow netresearch/jsonmapper ^3.0 and ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "netresearch/jsonmapper": "^1.0 || ^2.0",
+        "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
fixes #51 