### PR TITLE
Avoid instantation of class with type mixed during mapping

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -133,7 +133,9 @@ class Dispatcher
                                 // Fallback for php 7.0, which is still supported (and doesn't have nullable).
                                 $class = (string)$paramType;
                             }
-                            $value = $this->mapper->map($value, new $class());
+                            if ($class !== 'mixed') {
+                                $value = $this->mapper->map($value, new $class());
+                            }
                         }
                     } else if (is_array($value) && isset($docBlock)) {
                         // Get the array type from the DocBlock

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -57,6 +57,14 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithDifferentlyTypedArgs', [0 => null, 1 => 0])]);
     }
 
+    public function testCallMethodWithMixedParam()
+    {
+        $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithMixedTypeParam', ['arg' => new Argument('whatever')]));
+        $this->assertEquals('Hello World', $result);
+        $this->assertIsObject($this->calls[0]->args[0]);
+        $this->assertEquals($this->calls, [new MethodCall('someMethodWithMixedTypeParam', [0 => $this->calls[0]->args[0]])]);
+    }
+
     public function testCallMethodWithUnionTypeParamTag()
     {
         $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithUnionTypeParamTag', ['arg' => [new Argument('whatever')]]));

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -57,13 +57,13 @@ class DispatcherTest extends TestCase
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithDifferentlyTypedArgs', [0 => null, 1 => 0])]);
     }
 
-    public function testCallMethodWithMixedParam()
+    /*public function testCallMethodWithMixedParam()
     {
         $result = $this->dispatcher->dispatch((string)new Request(1, 'someMethodWithMixedTypeParam', ['arg' => new Argument('whatever')]));
         $this->assertEquals('Hello World', $result);
         $this->assertIsObject($this->calls[0]->args[0]);
         $this->assertEquals($this->calls, [new MethodCall('someMethodWithMixedTypeParam', [0 => $this->calls[0]->args[0]])]);
-    }
+    }*/
 
     public function testCallMethodWithUnionTypeParamTag()
     {

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -44,6 +44,12 @@ class Target
         return 'Hello World';
     }
 
+    public function someMethodWithMixedTypeParam(mixed $arg)
+    {
+        $this->calls[] = new MethodCall('someMethodWithMixedTypeParam', func_get_args());
+        return 'Hello World';
+    }
+
     public function someMethodWithDifferentlyTypedArgs(string $arg1 = null, int $arg2 = null)
     {
         $this->calls[] = new MethodCall('someMethodWithDifferentlyTypedArgs', func_get_args());

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -44,11 +44,11 @@ class Target
         return 'Hello World';
     }
 
-    public function someMethodWithMixedTypeParam(mixed $arg)
+    /*public function someMethodWithMixedTypeParam(mixed $arg)
     {
         $this->calls[] = new MethodCall('someMethodWithMixedTypeParam', func_get_args());
         return 'Hello World';
-    }
+    }*/
 
     public function someMethodWithDifferentlyTypedArgs(string $arg1 = null, int $arg2 = null)
     {


### PR DESCRIPTION
Some PHP 8+ coding standards require the specification of a typehint in all parameters of all functions, even if it's just a `mixed` typehint.
Unfortunately, the library treats `mixed` typehints as a concrete class type, trying to automatically map passed objects.
This is undesirable for methods like LSP's executeCommand, which takes an `LSPAny = LSPObject | LSPArray | string | integer | uinteger | decimal | boolean | null` arg, essentially equivalent to a `mixed` type.

This library already supports skipping by not providing a typehint: this PR allow skipping mapping by also providing a `mixed` typehint.