### PR TITLE
fix: Implicitly nullable parameter types are deprecated in PHP 8.4

### DIFF
--- a/lib/Error.php
+++ b/lib/Error.php
@@ -30,7 +30,7 @@ class Error extends Exception
      */
     public $data;
 
-    public function __construct(string $message, int $code, $data = null, Throwable $previous = null)
+    public function __construct(string $message, int $code, $data = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->data = $data;

--- a/tests/Argument.php
+++ b/tests/Argument.php
@@ -13,7 +13,7 @@ class Argument
      */
     public $aProperty;
 
-    public function __construct(string $aProperty = null)
+    public function __construct(?string $aProperty = null)
     {
         $this->aProperty = $aProperty;
     }

--- a/tests/Target.php
+++ b/tests/Target.php
@@ -44,7 +44,7 @@ class Target
         return 'Hello World';
     }
 
-    public function someMethodWithDifferentlyTypedArgs(string $arg1 = null, int $arg2 = null)
+    public function someMethodWithDifferentlyTypedArgs(?string $arg1 = null, ?int $arg2 = null)
     {
         $this->calls[] = new MethodCall('someMethodWithDifferentlyTypedArgs', func_get_args());
         return 'Hello World';


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4
* https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

`?Type` syntax was added in PHP 7.1, so there are no backward compatibility issues.
* https://wiki.php.net/rfc/nullable_types